### PR TITLE
Switch to BOOST_NORETURN macro

### DIFF
--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -26,7 +26,6 @@
 //  http://www.boost.org/libs/utility/throw_exception.html
 //
 
-#include <boost/exception/detail/attribute_noreturn.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/config.hpp>
 #include <exception>
@@ -56,7 +55,7 @@ void throw_exception( std::exception const & e ); // user defined
 
 inline void throw_exception_assert_compatibility( std::exception const & ) { }
 
-template<class E> BOOST_ATTRIBUTE_NORETURN inline void throw_exception( E const & e )
+template<class E> BOOST_NORETURN inline void throw_exception( E const & e )
 {
     //All boost exceptions are required to derive from std::exception,
     //to ensure compatibility with BOOST_NO_EXCEPTIONS.
@@ -76,7 +75,7 @@ template<class E> BOOST_ATTRIBUTE_NORETURN inline void throw_exception( E const 
     exception_detail
     {
         template <class E>
-        BOOST_ATTRIBUTE_NORETURN
+        BOOST_NORETURN
         void
         throw_exception_( E const & x, char const * current_function, char const * file, int line )
         {


### PR DESCRIPTION
Boost.Config now defines BOOST_NORETURN macro which is equivalent to BOOST_ATTRIBUTE_NORETURN. boost/exception/detail/attribute_noreturn.hpp can be removed as well, if no longer needed anywhere.
