### PR TITLE
Switch to BOOST_NORETURN macro

### DIFF
--- a/include/boost/exception/detail/exception_ptr.hpp
+++ b/include/boost/exception/detail/exception_ptr.hpp
@@ -34,7 +34,7 @@ namespace
 boost
     {
     class exception_ptr;
-    BOOST_ATTRIBUTE_NORETURN void rethrow_exception( exception_ptr const & );
+    BOOST_NORETURN void rethrow_exception( exception_ptr const & );
     exception_ptr current_exception();
 
     class
@@ -454,7 +454,7 @@ boost
         return ret;
         }
 
-    BOOST_ATTRIBUTE_NORETURN
+    BOOST_NORETURN
     inline
     void
     rethrow_exception( exception_ptr const & p )


### PR DESCRIPTION
Switch to BOOST_NORETURN macro provided by Boost.Config.
