### PR TITLE
Port to Boost.Core demangle() and typeinfo.

### DIFF
--- a/include/boost/exception/detail/exception_ptr.hpp
+++ b/include/boost/exception/detail/exception_ptr.hpp
@@ -22,7 +22,7 @@
 #include <boost/exception/detail/type_info.hpp>
 #include <boost/exception/detail/clone_current_exception.hpp>
 #ifndef BOOST_NO_RTTI
-#include <boost/exception/detail/type_info.hpp> // exception_detail::demangle()
+#include <boost/core/demangle.hpp>
 #endif
 #include <boost/shared_ptr.hpp>
 #include <stdexcept>
@@ -92,7 +92,7 @@ boost
     std::string
     to_string( original_exception_type const & x )
         {
-        return exception_detail::demangle(x.value()->name());
+        return core::demangle(x.value()->name());
         }
 #endif
 

--- a/include/boost/exception/detail/type_info.hpp
+++ b/include/boost/exception/detail/type_info.hpp
@@ -12,46 +12,15 @@
 #pragma warning(push,1)
 #endif
 
-#include <boost/detail/sp_typeinfo.hpp>
+#include <boost/core/typeinfo.hpp>
+#include <boost/core/demangle.hpp>
 #include <boost/current_function.hpp>
 #include <boost/config.hpp>
 #include <string>
-#if defined(__GLIBCXX__) || defined(__GLIBCPP__)
-#include <cxxabi.h>
-#include <stdlib.h>
-#include <stddef.h>
-#define BOOST_EXCEPTION_HAS_CXXABI_H
-#endif
 
 namespace
 boost
     {
-    namespace
-    exception_detail
-        {
-        inline
-        std::string
-        demangle(const char* name)
-            {
-#ifdef BOOST_EXCEPTION_HAS_CXXABI_H
-            struct auto_free
-                {
-                explicit auto_free(char* ptr) : p(ptr) {}
-                ~auto_free() { free(p); }
-                char* p;
-                };
-
-            int status = 0;
-            size_t size = 0;
-            auto_free demangled(abi::__cxa_demangle(name, NULL, &size, &status));
-
-            if (demangled.p)
-                return demangled.p;
-#endif
-            return name;
-            }
-        }
-
     template <class T>
     inline
     std::string
@@ -60,7 +29,7 @@ boost
 #ifdef BOOST_NO_TYPEID
         return BOOST_CURRENT_FUNCTION;
 #else
-        return exception_detail::demangle(typeid(T*).name());
+        return core::demangle(typeid(T*).name());
 #endif
         }
 
@@ -72,7 +41,7 @@ boost
 #ifdef BOOST_NO_TYPEID
         return BOOST_CURRENT_FUNCTION;
 #else
-        return exception_detail::demangle(typeid(T).name());
+        return core::demangle(typeid(T).name());
 #endif
         }
 
@@ -82,10 +51,10 @@ boost
         struct
         type_info_
             {
-            detail::sp_typeinfo const * type_;
+            core::typeinfo const * type_;
 
             explicit
-            type_info_( detail::sp_typeinfo const & type ):
+            type_info_( core::typeinfo const & type ):
                 type_(&type)
                 {
                 }
@@ -100,7 +69,7 @@ boost
         }
     }
 
-#define BOOST_EXCEPTION_STATIC_TYPEID(T) ::boost::exception_detail::type_info_(BOOST_SP_TYPEID(T))
+#define BOOST_EXCEPTION_STATIC_TYPEID(T) ::boost::exception_detail::type_info_(BOOST_CORE_TYPEID(T))
 
 #ifndef BOOST_NO_RTTI
 #define BOOST_EXCEPTION_DYNAMIC_TYPEID(x) ::boost::exception_detail::type_info_(typeid(x))

--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -17,7 +17,7 @@
 #include <boost/exception/info.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifndef BOOST_NO_RTTI
-#include <boost/exception/detail/type_info.hpp> // exception_detail::demangle()
+#include <boost/core/demangle.hpp>
 #endif
 #include <exception>
 #include <sstream>
@@ -151,7 +151,7 @@ boost
 #ifndef BOOST_NO_RTTI
             if ( verbose )
                 tmp << std::string("Dynamic exception type: ") <<
-                    exception_detail::demangle((be?(BOOST_EXCEPTION_DYNAMIC_TYPEID(*be)):(BOOST_EXCEPTION_DYNAMIC_TYPEID(*se))).type_->name()) << '\n';
+                    core::demangle((be?(BOOST_EXCEPTION_DYNAMIC_TYPEID(*be)):(BOOST_EXCEPTION_DYNAMIC_TYPEID(*se))).type_->name()) << '\n';
 #endif
             if( with_what && se && verbose )
                 tmp << "std::exception::what: " << wh << '\n';


### PR DESCRIPTION
The demangle() and typeinfo components were moved to Boost.Core. The pull request makes use of these changes.
