### PR TITLE
added support for error_info r-value references

### DIFF
--- a/include/boost/exception/detail/error_info_impl.hpp
+++ b/include/boost/exception/detail/error_info_impl.hpp
@@ -12,6 +12,7 @@
 #pragma warning(push,1)
 #endif
 
+#include <boost/config.hpp>
 #include <string>
 
 namespace
@@ -46,6 +47,13 @@ boost
         typedef T value_type;
 
         error_info( value_type const & value );
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+        error_info( value_type && value);
+        error_info( error_info const & ) = default;
+        error_info( error_info && ) = default;
+        error_info& operator=( error_info const & ) = default;
+        error_info& operator=( error_info && ) = default;
+#endif
         ~error_info() throw();
 
         value_type const &

--- a/include/boost/exception/detail/error_info_impl.hpp
+++ b/include/boost/exception/detail/error_info_impl.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/config.hpp>
 #include <string>
+#include <utility>
 
 namespace
 boost
@@ -48,11 +49,13 @@ boost
 
         error_info( value_type const & value );
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-        error_info( value_type && value);
-        error_info( error_info const & ) = default;
-        error_info( error_info && ) = default;
-        error_info& operator=( error_info const & ) = default;
-        error_info& operator=( error_info && ) = default;
+        error_info( value_type && value );
+        error_info( error_info const & );
+        error_info( error_info && other ) 
+            BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(value_type(std::move(other.value_))));
+        error_info& operator=( error_info const & other );
+        error_info& operator=( error_info && other ) 
+            BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(other.value_ = std::move(other.value_)));
 #endif
         ~error_info() throw();
 

--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -16,8 +16,10 @@
 #include <boost/exception/to_string_stub.hpp>
 #include <boost/exception/detail/error_info_impl.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/config.hpp>
 #include <map>
+#include <utility>
 
 namespace
 boost
@@ -53,6 +55,44 @@ boost
     error_info( value_type && value ):
         value_(std::move(value))
         {
+        }
+
+    template <class Tag,class T>
+    inline
+    error_info<Tag,T>::
+    error_info( error_info const & other ):
+        value_(other.value_)
+        {
+        }
+
+    template <class Tag,class T>
+    inline
+    error_info<Tag,T>::
+    error_info( error_info && other ) 
+        BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(value_type(std::move(other.value_))))
+      : value_(std::move(other.value_))
+        {
+        }
+
+    template <class Tag,class T>
+    inline
+    error_info<Tag,T>& 
+    error_info<Tag,T>::
+    operator=( error_info const & other )
+        {
+          value_ = other.value_;
+          return *this;
+        }
+
+    template <class Tag,class T>
+    inline
+    error_info<Tag,T>& 
+    error_info<Tag,T>::
+    operator=( error_info && other ) 
+        BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT_EXPR(other.value_ = std::move(other.value_)))
+        {
+          value_ = std::move(other.value_);
+          return *this;
         }
 #endif
 
@@ -192,7 +232,7 @@ boost
         set_info( E const & x, error_info<Tag,T> && v )
             {
             typedef error_info<Tag,T> error_info_tag_t;
-            shared_ptr<error_info_tag_t> p( new error_info_tag_t(std::move(v)) );
+            shared_ptr<error_info_tag_t> p = boost::make_shared<error_info_tag_t>(std::move(v));
             exception_detail::error_info_container * c=x.data_.get();
             if( !c )
                 x.data_.adopt(c=new exception_detail::error_info_container_impl);

--- a/test/error_info_test.cpp
+++ b/test/error_info_test.cpp
@@ -73,9 +73,11 @@ throws_on_copy
 struct
 move_only
     {
-    move_only() = default;
+    move_only(int x) : x_(x) {}
+    move_only( move_only && other ) : x_(other.x_) {}
+    int x_;
+   private:
     move_only( move_only const & ) = delete;
-    move_only( move_only && ) = default;
     };
 #endif
   
@@ -154,7 +156,7 @@ throw_test_2()
 void
 throw_test_3()
     {
-    throw test_exception() << test_8(move_only());
+    throw test_exception() << test_8(move_only(7));
     }
 #endif
 
@@ -260,6 +262,7 @@ test_basic_throw_catch()
     boost::exception & x )
         {
         BOOST_TEST(boost::get_error_info<test_8>(x));
+        BOOST_TEST(boost::get_error_info<test_8>(x)->x_ == 7);
         }
     catch(
     ... )

--- a/test/error_info_test.cpp
+++ b/test/error_info_test.cpp
@@ -11,6 +11,9 @@
 
 struct throws_on_copy;
 struct non_printable { };
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+struct move_only;
+#endif
 
 struct
 user_data
@@ -43,6 +46,9 @@ typedef boost::error_info<struct tag_test_4,throws_on_copy> test_4;
 typedef boost::error_info<struct tag_test_5,std::string> test_5;
 typedef boost::error_info<struct tag_test_6,non_printable> test_6;
 typedef boost::error_info<struct tag_user_data,user_data> test_7;
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+typedef boost::error_info<struct tag_test_8,move_only> test_8;
+#endif
 
 struct
 test_exception:
@@ -62,6 +68,17 @@ throws_on_copy
         throw test_exception();
         }
     };
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+struct
+move_only
+    {
+    move_only() = default;
+    move_only( move_only const & ) = delete;
+    move_only( move_only && ) = default;
+    };
+#endif
+  
 
 void
 basic_test()
@@ -132,6 +149,14 @@ throw_test_2()
     {
     throw test_exception() << test_6(non_printable());
     }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+void
+throw_test_3()
+    {
+    throw test_exception() << test_8(move_only());
+    }
+#endif
 
 void
 throw_catch_add_file_name( char const * name )
@@ -224,6 +249,24 @@ test_basic_throw_catch()
         {
         BOOST_TEST(false);
         }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    try
+        {
+        throw_test_3();
+        BOOST_ASSERT(false);
+        }
+    catch(
+    boost::exception & x )
+        {
+        BOOST_TEST(boost::get_error_info<test_8>(x));
+        }
+    catch(
+    ... )
+        {
+        BOOST_TEST(false);
+        }
+#endif
     }
 
 void


### PR DESCRIPTION
adds support to transport exception data using move semantics

Example:

```
boost::exception e;
typedef boost::error_info<struct tag,Data> ErrorInfo;
Data data;
e << ErrorInfo(std::move(data));
throw e;
```
