### PR TITLE
Don't include stuff inside #pragma warning push/pop, include boost/config.hpp before testing BOOST_ macros.

### DIFF
--- a/include/boost/exception/N3757.hpp
+++ b/include/boost/exception/N3757.hpp
@@ -5,15 +5,17 @@
 
 #ifndef UUID_9011016A11A711E3B46CD9FA6088709B
 #define UUID_9011016A11A711E3B46CD9FA6088709B
+
+#include <boost/config.hpp>
+#include <boost/exception/info.hpp>
+#include <boost/exception/get_error_info.hpp>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/exception/info.hpp>
-#include <boost/exception/get_error_info.hpp>
 
 namespace
 boost

--- a/include/boost/exception/all.hpp
+++ b/include/boost/exception/all.hpp
@@ -5,12 +5,6 @@
 
 #ifndef UUID_316FDA946C0D11DEA9CBAE5255D89593
 #define UUID_316FDA946C0D11DEA9CBAE5255D89593
-#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma GCC system_header
-#endif
-#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma warning(push,1)
-#endif
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/exception/error_info.hpp>
@@ -30,7 +24,4 @@
 #include <boost/exception_ptr.hpp>
 #endif
 
-#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma warning(pop)
-#endif
 #endif

--- a/include/boost/exception/current_exception_cast.hpp
+++ b/include/boost/exception/current_exception_cast.hpp
@@ -5,6 +5,9 @@
 
 #ifndef UUID_7E83C166200811DE885E826156D89593
 #define UUID_7E83C166200811DE885E826156D89593
+
+#include <boost/config.hpp>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif

--- a/include/boost/exception/detail/clone_current_exception.hpp
+++ b/include/boost/exception/detail/clone_current_exception.hpp
@@ -5,15 +5,18 @@
 
 #ifndef UUID_81522C0EB56511DFAB613DB0DFD72085
 #define UUID_81522C0EB56511DFAB613DB0DFD72085
+
+#include <boost/config.hpp>
+
+#ifdef BOOST_NO_EXCEPTIONS
+#    error This header requires exception handling to be enabled.
+#endif
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
-#endif
-
-#ifdef BOOST_NO_EXCEPTIONS
-#    error This header requires exception handling to be enabled.
 #endif
 
 namespace

--- a/include/boost/exception/detail/error_info_impl.hpp
+++ b/include/boost/exception/detail/error_info_impl.hpp
@@ -5,16 +5,17 @@
 
 #ifndef UUID_CE6983AC753411DDA764247956D89593
 #define UUID_CE6983AC753411DDA764247956D89593
+
+#include <boost/config.hpp>
+#include <utility>
+#include <string>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/config.hpp>
-#include <utility>
-#include <string>
 
 namespace
 boost
@@ -49,6 +50,7 @@ boost
             v_(v)
             {
             }
+#if (__GNUC__*100+__GNUC_MINOR__!=406) //workaround for g++ bug
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
         error_info( error_info const & x ):
             v_(x.v_)
@@ -62,6 +64,7 @@ boost
             v_(std::move(x.v_))
             {
             }
+#endif
 #endif
         ~error_info() throw()
             {

--- a/include/boost/exception/detail/exception_ptr.hpp
+++ b/include/boost/exception/detail/exception_ptr.hpp
@@ -5,12 +5,6 @@
 
 #ifndef UUID_618474C2DE1511DEB74A388C56D89593
 #define UUID_618474C2DE1511DEB74A388C56D89593
-#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma GCC system_header
-#endif
-#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma warning(push,1)
-#endif
 
 #include <boost/config.hpp>
 #ifdef BOOST_NO_EXCEPTIONS
@@ -29,6 +23,13 @@
 #include <new>
 #include <ios>
 #include <stdlib.h>
+
+#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma GCC system_header
+#endif
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(push,1)
+#endif
 
 namespace
 boost

--- a/include/boost/exception/detail/is_output_streamable.hpp
+++ b/include/boost/exception/detail/is_output_streamable.hpp
@@ -5,14 +5,16 @@
 
 #ifndef UUID_898984B4076411DD973EDFA055D89593
 #define UUID_898984B4076411DD973EDFA055D89593
+
+#include <boost/config.hpp>
+#include <ostream>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <ostream>
 
 namespace
 boost

--- a/include/boost/exception/detail/object_hex_dump.hpp
+++ b/include/boost/exception/detail/object_hex_dump.hpp
@@ -5,19 +5,21 @@
 
 #ifndef UUID_6F463AC838DF11DDA3E6909F56D89593
 #define UUID_6F463AC838DF11DDA3E6909F56D89593
-#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma GCC system_header
-#endif
-#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma warning(push,1)
-#endif
 
+#include <boost/config.hpp>
 #include <boost/exception/detail/type_info.hpp>
 #include <iomanip>
 #include <ios>
 #include <string>
 #include <sstream>
 #include <cstdlib>
+
+#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma GCC system_header
+#endif
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(push,1)
+#endif
 
 namespace
 boost

--- a/include/boost/exception/detail/type_info.hpp
+++ b/include/boost/exception/detail/type_info.hpp
@@ -5,18 +5,19 @@
 
 #ifndef UUID_C3E1741C754311DDB2834CCA55D89593
 #define UUID_C3E1741C754311DDB2834CCA55D89593
+
+#include <boost/config.hpp>
+#include <boost/core/typeinfo.hpp>
+#include <boost/core/demangle.hpp>
+#include <boost/current_function.hpp>
+#include <string>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/core/typeinfo.hpp>
-#include <boost/core/demangle.hpp>
-#include <boost/current_function.hpp>
-#include <boost/config.hpp>
-#include <string>
 
 namespace
 boost

--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -5,16 +5,13 @@
 
 #ifndef UUID_0552D49838DD11DD90146B8956D89593
 #define UUID_0552D49838DD11DD90146B8956D89593
-#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma GCC system_header
-#endif
-#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
-#pragma warning(push,1)
-#endif
 
 #include <boost/config.hpp>
 #include <boost/exception/get_error_info.hpp>
 #include <boost/exception/info.hpp>
+#ifndef BOOST_NO_EXCEPTIONS
+#include <boost/exception/current_exception_cast.hpp>
+#endif
 #include <boost/utility/enable_if.hpp>
 #ifndef BOOST_NO_RTTI
 #include <boost/core/demangle.hpp>
@@ -23,8 +20,14 @@
 #include <sstream>
 #include <string>
 
+#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma GCC system_header
+#endif
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(push,1)
+#endif
+
 #ifndef BOOST_NO_EXCEPTIONS
-#include <boost/exception/current_exception_cast.hpp>
 namespace
 boost
     {

--- a/include/boost/exception/errinfo_errno.hpp
+++ b/include/boost/exception/errinfo_errno.hpp
@@ -5,6 +5,12 @@
 
 #ifndef UUID_F0EE17BE6C1211DE87FF459155D89593
 #define UUID_F0EE17BE6C1211DE87FF459155D89593
+
+#include <boost/config.hpp>
+#include <boost/exception/info.hpp>
+#include <errno.h>
+#include <string.h>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
@@ -12,10 +18,6 @@
 #pragma warning(push,1)
 #pragma warning(disable:4996)
 #endif
-
-#include <boost/exception/info.hpp>
-#include <errno.h>
-#include <string.h>
 
 namespace
 boost

--- a/include/boost/exception/get_error_info.hpp
+++ b/include/boost/exception/get_error_info.hpp
@@ -5,18 +5,20 @@
 
 #ifndef UUID_1A590226753311DD9E4CCF6156D89593
 #define UUID_1A590226753311DD9E4CCF6156D89593
+
+#include <boost/config.hpp>
+#include <boost/exception/exception.hpp>
+#include <boost/exception/detail/error_info_impl.hpp>
+#include <boost/exception/detail/type_info.hpp>
+#include <boost/exception/detail/shared_ptr.hpp>
+#include <boost/assert.hpp>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/exception/exception.hpp>
-#include <boost/exception/detail/error_info_impl.hpp>
-#include <boost/exception/detail/type_info.hpp>
-#include <boost/exception/detail/shared_ptr.hpp>
-#include <boost/assert.hpp>
 
 namespace
 boost

--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -5,19 +5,20 @@
 
 #ifndef UUID_8D22C4CA9CC811DCAA9133D256D89593
 #define UUID_8D22C4CA9CC811DCAA9133D256D89593
+
+#include <boost/config.hpp>
+#include <boost/exception/exception.hpp>
+#include <boost/exception/to_string_stub.hpp>
+#include <boost/exception/detail/error_info_impl.hpp>
+#include <boost/exception/detail/shared_ptr.hpp>
+#include <map>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/exception/exception.hpp>
-#include <boost/exception/to_string_stub.hpp>
-#include <boost/exception/detail/error_info_impl.hpp>
-#include <boost/exception/detail/shared_ptr.hpp>
-#include <boost/config.hpp>
-#include <map>
 
 namespace
 boost

--- a/include/boost/exception/info_tuple.hpp
+++ b/include/boost/exception/info_tuple.hpp
@@ -5,15 +5,17 @@
 
 #ifndef UUID_63EE924290FB11DC87BB856555D89593
 #define UUID_63EE924290FB11DC87BB856555D89593
+
+#include <boost/config.hpp>
+#include <boost/exception/info.hpp>
+#include <boost/tuple/tuple.hpp>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/exception/info.hpp>
-#include <boost/tuple/tuple.hpp>
 
 namespace
 boost

--- a/include/boost/exception/to_string.hpp
+++ b/include/boost/exception/to_string.hpp
@@ -5,16 +5,18 @@
 
 #ifndef UUID_7E48761AD92811DC9011477D56D89593
 #define UUID_7E48761AD92811DC9011477D56D89593
+
+#include <boost/config.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/exception/detail/is_output_streamable.hpp>
+#include <sstream>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/utility/enable_if.hpp>
-#include <boost/exception/detail/is_output_streamable.hpp>
-#include <sstream>
 
 namespace
 boost

--- a/include/boost/exception/to_string_stub.hpp
+++ b/include/boost/exception/to_string_stub.hpp
@@ -5,16 +5,18 @@
 
 #ifndef UUID_E788439ED9F011DCB181F25B55D89593
 #define UUID_E788439ED9F011DCB181F25B55D89593
+
+#include <boost/config.hpp>
+#include <boost/exception/to_string.hpp>
+#include <boost/exception/detail/object_hex_dump.hpp>
+#include <boost/assert.hpp>
+
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
 #endif
-
-#include <boost/exception/to_string.hpp>
-#include <boost/exception/detail/object_hex_dump.hpp>
-#include <boost/assert.hpp>
 
 namespace
 boost


### PR DESCRIPTION
I've moved some #include lines around + added #include <boost/config.hpp> lines to some files to avoid...
- testing BOOST_* macros before config.hpp was included
- including other header files inside #pragma warning push/pop pairs

We're building with warnings=errors, and including e.g. <boost/config.hpp> for the first time inside a #pragma warning push/pop pair means all #pragma warning disable that are done in config.hpp will be undone by the pop. Which means our builds will fail because of some upgraded warning. Also I think it's generally not a good idea to include files inside a #pragma warning push/pop pair.

And of course every file that tests/uses some BOOST_* macro should include <boost/config.hpp> first, to e.g. give Boost.Config and/or <config/user.hpp> the change to define that macro.
