### PR TITLE
error_info_container : let msvc accept a non virtual protected destructor

### DIFF
--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -18,6 +18,7 @@
 #endif
 #if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma warning(push,1)
+#pragma warning(disable: 4265)
 #endif
 
 namespace


### PR DESCRIPTION
Hi,

Here is a proposition for a patch on error_info_container : it has a non virtual protected destructor (which is legitimate). However, Visual Studio sees this as a bug, if you enable more warnings (as is often required, because the default warning level is insuffficient).

For a full test and working example, see https://github.com/ivsgroup/boost_warnings_minimal_demo

Important: I tested this patch on a raw boost 1.64.0 checkout, I could not test it on the develop branch.

Hoping that this will be useful,
Regards,
Pascal Thomet
