### PR TITLE
Fully qualify error_info_base for Visual C++ 7.1

### DIFF
--- a/include/boost/exception/detail/error_info_impl.hpp
+++ b/include/boost/exception/detail/error_info_impl.hpp
@@ -46,7 +46,7 @@ boost
     error_info:
         public exception_detail::error_info_base
         {
-        error_info_base *
+        exception_detail::error_info_base *
         clone() const
             {
             return new error_info<Tag,T>(*this);


### PR DESCRIPTION
Test are failing on Visual C++ 7.1, I think because it's not importing
error_info_base into the class' namespace, so hopefully this will fix it. I
don't have access to the compiler, so I'm not sure.