### PR TITLE
[CMake] Add minimal cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Exception is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostException LANGUAGES CXX)
+
+
+add_library(boost_exception src/clone_current_exception_non_intrusive.cpp)
+add_library(Boost::exception ALIAS boost_exception)
+
+target_include_directories(boost_exception PUBLIC include)
+
+target_link_libraries(boost_exception
+    PUBLIC
+        Boost::assert
+        Boost::config
+        Boost::core
+        Boost::smart_ptr
+        Boost::throw_exception
+        Boost::tuple
+        Boost::type_traits
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Mike Dev
+# Copyright 2019 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,24 @@
 # Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
-# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 #
 # NOTE: CMake support for Boost.Exception is currently experimental at best
 #       and the interface is likely to change in the future
 
-cmake_minimum_required(VERSION 3.5)
-project(BoostException LANGUAGES CXX)
+cmake_minimum_required( VERSION 3.5 )
+project( BoostException LANGUAGES CXX )
 
+# We treat Boost.Exception as header only for now.
+# See https://github.com/boostorg/exception/pull/17
+# for more information.
 
-add_library(boost_exception src/clone_current_exception_non_intrusive.cpp)
-add_library(Boost::exception ALIAS boost_exception)
+add_library( boost_exception INTERFACE )
+add_library( Boost::exception ALIAS boost_exception )
 
-target_include_directories(boost_exception PUBLIC include)
+target_include_directories( boost_exception PUBLIC include )
 
-target_link_libraries(boost_exception
-    PUBLIC
+target_link_libraries( boost_exception
+    INTERFACE
         Boost::assert
         Boost::config
         Boost::core


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling

    add_subdirectory( <path-to-boost_exception> )
    target_link_libraries( <my_lib> PUBLIC Boost::exception )

More information:

- https://groups.google.com/forum/#!topic/boost-developers-archive/kM4JRmyVl3M%5B1-25%5D
- https://groups.google.com/d/msg/boost-developers-archive/4HU-RzReL7U/FS1X6OFrEQAJ
- https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU

Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.