### PR TITLE
Extract exception type name from std::exception_ptr on libstdc++

### DIFF
--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -45,6 +45,10 @@ boost
         std::exception const * se=current_exception_cast<std::exception const>();
         if( be || se )
             return exception_detail::diagnostic_information_impl(be,se,true,verbose);
+#if defined(__GLIBCXX__) && __cplusplus >= 201103L && !defined(BOOST_NO_RTTI)
+        else if (auto* p=std::current_exception().__cxa_exception_type())
+            return "Dynamic exception type: "+boost::core::demangle(p->name());
+#endif
         else
             return "No diagnostic information available.";
         }


### PR DESCRIPTION
There's a public function https://github.com/gcc-mirror/gcc/blob/41d6b10e96a1de98e90a7c0378437c3255814b16/libstdc%2B%2B-v3/libsupc%2B%2B/exception_ptr.h#L153 that returns `std::type_info` of the exception.