### PR TITLE
Replaced throw() with BOOST_NOEXCEPT_OR_NOTHROW

### DIFF
--- a/example/example_io.cpp
+++ b/example/example_io.cpp
@@ -35,14 +35,14 @@ error: //Base for all exception objects we throw.
     public:
 
     char const *
-    what() const throw()
+    what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return "example_io error";
         }
 
     protected:
 
-    ~error() throw()
+    ~error() BOOST_NOEXCEPT_OR_NOTHROW
         {
         }
     };

--- a/include/boost/exception/detail/error_info_impl.hpp
+++ b/include/boost/exception/detail/error_info_impl.hpp
@@ -35,7 +35,7 @@ boost
             virtual error_info_base * clone() const = 0;
 
             virtual
-            ~error_info_base() throw()
+            ~error_info_base() BOOST_NOEXCEPT_OR_NOTHROW
                 {
                 }
             };
@@ -73,7 +73,7 @@ boost
             }
 #endif
 #endif
-        ~error_info() throw()
+        ~error_info() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
         value_type const &

--- a/include/boost/exception/detail/exception_ptr.hpp
+++ b/include/boost/exception/detail/exception_ptr.hpp
@@ -105,7 +105,7 @@ boost
             boost::exception,
             std::bad_alloc
                 {
-                ~bad_alloc_() throw() { }
+                ~bad_alloc_() BOOST_NOEXCEPT_OR_NOTHROW { }
                 };
 
         struct
@@ -113,7 +113,7 @@ boost
             boost::exception,
             std::bad_exception
                 {
-                ~bad_exception_() throw() { }
+                ~bad_exception_() BOOST_NOEXCEPT_OR_NOTHROW { }
                 };
 
         template <class Exception>
@@ -174,7 +174,7 @@ boost
             add_original_type(e);
             }
 
-        ~unknown_exception() throw()
+        ~unknown_exception() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
 
@@ -220,7 +220,7 @@ boost
                 add_original_type(e1);
                 }
 
-            ~current_exception_std_exception_wrapper() throw()
+            ~current_exception_std_exception_wrapper() BOOST_NOEXCEPT_OR_NOTHROW
                 {
                 }
 

--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -175,7 +175,7 @@ boost
 
     inline
     char const *
-    diagnostic_information_what( exception const & e, bool verbose=true ) throw()
+    diagnostic_information_what( exception const & e, bool verbose=true ) BOOST_NOEXCEPT_OR_NOTHROW
         {
         char const * w=0;
 #ifndef BOOST_NO_EXCEPTIONS

--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -62,7 +62,7 @@ boost
                 {
                 }
 
-            ~error_info_container_impl() throw()
+            ~error_info_container_impl() BOOST_NOEXCEPT_OR_NOTHROW
                 {
                 }
 

--- a/src/clone_current_exception_non_intrusive.cpp
+++ b/src/clone_current_exception_non_intrusive.cpp
@@ -230,7 +230,7 @@ namespace
             {
             }
 
-        ~cloned_exception() throw()
+        ~cloned_exception() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
 

--- a/test/cloning_test.cpp
+++ b/test/cloning_test.cpp
@@ -73,7 +73,7 @@ derives_std_boost_exception:
         {
         }
 
-    char const * what() const throw()
+    char const * what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return wh_;
         }

--- a/test/copy_exception_test.cpp
+++ b/test/copy_exception_test.cpp
@@ -29,7 +29,7 @@ err:
         }
 
     virtual
-    ~err() throw()
+    ~err() BOOST_NOEXCEPT_OR_NOTHROW
         {
         --exc_count;
         }

--- a/test/diagnostic_information_test.cpp
+++ b/test/diagnostic_information_test.cpp
@@ -28,7 +28,7 @@ error1:
     boost::exception
     {
     char const *
-    what() const throw()
+    what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return "error1";
         }
@@ -45,7 +45,7 @@ error3:
     std::exception
     {
     char const *
-    what() const throw()
+    what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return "error3";
         }
@@ -57,7 +57,7 @@ error4:
     boost::exception
     {
     char const *
-    what() const throw()
+    what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return diagnostic_information_what(*this);
         }

--- a/test/exception_ptr_test.cpp
+++ b/test/exception_ptr_test.cpp
@@ -87,7 +87,7 @@ exc:
         }
 
     virtual
-    ~exc() throw()
+    ~exc() BOOST_NOEXCEPT_OR_NOTHROW
         {
         --exc_count;
         }

--- a/test/helper2.cpp
+++ b/test/helper2.cpp
@@ -20,7 +20,7 @@ boost
             }
 
         derives_boost_exception::
-        ~derives_boost_exception() throw()
+        ~derives_boost_exception() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
 
@@ -32,7 +32,7 @@ boost
             }
 
         derives_boost_exception_virtually::
-        ~derives_boost_exception_virtually() throw()
+        ~derives_boost_exception_virtually() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
 
@@ -44,7 +44,7 @@ boost
             }
 
         derives_std_exception::
-        ~derives_std_exception() throw()
+        ~derives_std_exception() BOOST_NOEXCEPT_OR_NOTHROW
             {
             }
 

--- a/test/helper2.hpp
+++ b/test/helper2.hpp
@@ -21,7 +21,7 @@ boost
             public std::exception
             {
             explicit derives_boost_exception( int x );
-            virtual ~derives_boost_exception() throw();
+            virtual ~derives_boost_exception() BOOST_NOEXCEPT_OR_NOTHROW;
             int x_;
             };
 
@@ -31,7 +31,7 @@ boost
             public std::exception
             {
             explicit derives_boost_exception_virtually( int x );
-            virtual ~derives_boost_exception_virtually() throw();
+            virtual ~derives_boost_exception_virtually() BOOST_NOEXCEPT_OR_NOTHROW;
             int x_;
             };
 
@@ -40,7 +40,7 @@ boost
             public std::exception
             {
             explicit derives_std_exception( int x );
-            virtual ~derives_std_exception() throw();
+            virtual ~derives_std_exception() BOOST_NOEXCEPT_OR_NOTHROW;
             int x_;
             };
 

--- a/test/no_exceptions_test.cpp
+++ b/test/no_exceptions_test.cpp
@@ -17,7 +17,7 @@ my_exception:
     std::exception
     {
     char const *
-    what() const throw()
+    what() const BOOST_NOEXCEPT_OR_NOTHROW
         {
         return "my_exception";
         }


### PR DESCRIPTION
With throw(), Visual Studio 2017 emitted a warning "C26439 SPECIAL_NOEXCEPT". Reproducible at least if code analysis was set to level: "Microsoft Native Recommended Rules".

https://docs.microsoft.com/en-us/visualstudio/code-quality/c26439?view=vs-2017