### PR TITLE
Guard diagnostic_information against null what()

### DIFF
--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -161,7 +161,7 @@ boost
                     core::demangle((be?(BOOST_EXCEPTION_DYNAMIC_TYPEID(*be)):(BOOST_EXCEPTION_DYNAMIC_TYPEID(*se))).type_->name()) << '\n';
 #endif
             if( with_what && se && verbose )
-                tmp << "std::exception::what: " << wh << '\n';
+                tmp << "std::exception::what: " << (wh ? wh : "(null)") << '\n';
             if( be )
                 if( char const * s=exception_detail::get_diagnostic_information(*be,tmp.str().c_str()) )
                     if( *s )


### PR DESCRIPTION
Printing a `char*` nullptr to an `std::ostream` is UB. Since diagnostic_information is used for debugging, I guess it would be good for it to be as robust as possible.