### PR TITLE
fix(info): add support of error_info usage across shared libraries on…

### DIFF
--- a/include/boost/exception/detail/type_info.hpp
+++ b/include/boost/exception/detail/type_info.hpp
@@ -10,6 +10,9 @@
 #include <boost/core/typeinfo.hpp>
 #include <boost/core/demangle.hpp>
 #include <boost/current_function.hpp>
+#ifdef __APPLE__
+#include <boost/utility/string_view.hpp>
+#endif
 #include <string>
 
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
@@ -52,19 +55,42 @@ boost
         struct
         type_info_
             {
+        private:
             core::typeinfo const * type_;
 
+        public:
             explicit
             type_info_( core::typeinfo const & type ):
                 type_(&type)
                 {
                 }
 
+            const char * name() const
+                {
+                    return type_->name();
+                }
+
+            friend
+            bool
+            operator==( type_info_ const & a, type_info_ const & b )
+                {
+#ifdef __APPLE__
+                return boost::string_view(a.type_->name()) == boost::string_view(b.type_->name());
+#else
+                return (*a.type_) == (*b.type_);
+#endif
+                }
+
+
             friend
             bool
             operator<( type_info_ const & a, type_info_ const & b )
                 {
+#ifdef __APPLE__
+                return boost::string_view(a.type_->name()) < boost::string_view(b.type_->name());
+#else
                 return 0!=(a.type_->before(*b.type_));
+#endif
                 }
             };
         }

--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -158,7 +158,7 @@ boost
 #ifndef BOOST_NO_RTTI
             if ( verbose )
                 tmp << std::string("Dynamic exception type: ") <<
-                    core::demangle((be?(BOOST_EXCEPTION_DYNAMIC_TYPEID(*be)):(BOOST_EXCEPTION_DYNAMIC_TYPEID(*se))).type_->name()) << '\n';
+                    core::demangle((be?(BOOST_EXCEPTION_DYNAMIC_TYPEID(*be)):(BOOST_EXCEPTION_DYNAMIC_TYPEID(*se))).name()) << '\n';
 #endif
             if( with_what && se && verbose )
                 tmp << "std::exception::what: " << (wh ? wh : "(null)") << '\n';

--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -82,7 +82,7 @@ boost
                     {
                     shared_ptr<error_info_base> const & p = i->second;
 #ifndef BOOST_NO_RTTI
-                    BOOST_ASSERT( *BOOST_EXCEPTION_DYNAMIC_TYPEID(*p).type_==*ti.type_ );
+                    BOOST_ASSERT( BOOST_EXCEPTION_DYNAMIC_TYPEID(*p)==ti );
 #endif
                     return p;
                     }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -73,3 +73,7 @@ compile errinfo_nested_exception_hpp_test.cpp ;
 compile errinfo_type_info_name_hpp_test.cpp ;
 
 compile bug_11874_test.cpp ;
+
+lib shared_lib_throw_exception : shared_lib_throw_exception.cpp : <link>shared <visibility>global ;
+run errinfo_from_shared_lib.cpp shared_lib_throw_exception : : : <link>shared : errinfo_from_shared_lib_shared ;
+run errinfo_from_shared_lib.cpp shared_lib_throw_exception : : : <link>static : errinfo_from_shared_lib_static ;

--- a/test/errinfo_from_shared_lib.cpp
+++ b/test/errinfo_from_shared_lib.cpp
@@ -1,0 +1,25 @@
+//Copyright (c) 2006-2019 Emil Dotchevski and Reverge Studios, Inc.
+//Copyright (c) 2019-2019 David Callu
+
+//Distributed under the Boost Software License, Version 1.0. (See accompanying
+//file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "shared_lib_throw_exception.hpp"
+
+#include <boost/exception/get_error_info.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+int
+main()
+    {
+    try
+        {
+	boost::exception_test::throw_my_exception_with_error_info_string("doh");
+        }
+    catch( boost::exception & e )
+        {
+        BOOST_TEST(boost::get_error_info<boost::exception_test::error_info_string>(e) &&
+		   !strcmp(boost::get_error_info<boost::exception_test::error_info_string>(e)->c_str(),"doh"));
+        }
+    return boost::report_errors();
+    }

--- a/test/shared_lib_throw_exception.cpp
+++ b/test/shared_lib_throw_exception.cpp
@@ -1,0 +1,22 @@
+//Copyright (c) 2006-2019 Emil Dotchevski and Reverge Studios, Inc.
+//Copyright (c) 2019-2019 David Callu
+
+//Distributed under the Boost Software License, Version 1.0. (See accompanying
+//file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "shared_lib_throw_exception.hpp"
+
+#include <boost/exception/info.hpp>
+
+namespace
+boost
+    {
+    namespace
+    exception_test
+        {
+	void throw_my_exception_with_error_info_string( const std::string message )
+	    {
+	    throw my_exception() << error_info_string( message );
+	    }
+        }
+    }

--- a/test/shared_lib_throw_exception.hpp
+++ b/test/shared_lib_throw_exception.hpp
@@ -1,0 +1,28 @@
+//Copyright (c) 2006-2019 Emil Dotchevski and Reverge Studios, Inc.
+//Copyright (c) 2019-2019 David Callu
+
+//Distributed under the Boost Software License, Version 1.0. (See accompanying
+//file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef UUID_884f590590084f34be8437f87b774691
+#define UUID_884f590590084f34be8437f87b774691
+
+#include <boost/exception/error_info.hpp>
+#include <boost/exception/exception.hpp>
+
+#include <string>
+
+namespace
+boost
+    {
+    namespace
+    exception_test
+        {
+	struct my_exception: virtual boost::exception {};
+	typedef boost::error_info<struct error_info_string_, std::string> error_info_string;
+
+	void throw_my_exception_with_error_info_string( const std::string message );
+        }
+    }
+
+#endif


### PR DESCRIPTION
… MacOS

On MacOS, with apple-clang, std::type_info is not shared across dynamic
library, so equality test of std::type_info based on address failed. Use
std::type_info::name() instead.