### PR TITLE
Mark error_info_container_impl final

### DIFF
--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -52,7 +52,7 @@ boost
     exception_detail
         {
         class
-        error_info_container_impl:
+        error_info_container_impl BOOST_FINAL:
             public error_info_container
             {
             public:


### PR DESCRIPTION
This should allow for better code optimization and also silence compiler warnings about non-virtual destructor.