### PR TITLE
suppress warning

### DIFF
--- a/include/boost/exception/info.hpp
+++ b/include/boost/exception/info.hpp
@@ -31,7 +31,7 @@ boost
     template <class Tag,class T>
     inline
     std::string
-    error_info_name( error_info<Tag,T> const & x )
+    error_info_name( error_info<Tag,T> const & )
         {
         return tag_type_name<Tag>();
         }


### PR DESCRIPTION
I'm compiling with `/Wall /external:W3 /external:anglebrackets `<b>`/external:templates-`</b>
Also take note that msvc now supports `#pragma system_header`
https://docs.microsoft.com/en-us/cpp/build/reference/external-external-headers-diagnostics?view=msvc-160