### PR TITLE
Use enable_current_exception instead of wrapexcept in copy_exception

### DIFF
--- a/include/boost/exception/detail/exception_ptr.hpp
+++ b/include/boost/exception/detail/exception_ptr.hpp
@@ -112,14 +112,24 @@ boost
             }
         };
 
+    namespace
+    exception_detail
+        {
+        template <class E>
+        inline
+        exception_ptr
+        copy_exception_impl( E const & e )
+            {
+            return exception_ptr(boost::make_shared<E>(e));
+            }
+        }
+
     template <class E>
     inline
     exception_ptr
     copy_exception( E const & e )
         {
-        E cp = e;
-        exception_detail::copy_boost_exception(&cp, &e);
-        return exception_ptr(boost::make_shared<wrapexcept<E> >(cp));
+        return exception_detail::copy_exception_impl(boost::enable_current_exception(e));
         }
 
     template <class T>


### PR DESCRIPTION
Since `wrapexcept` is an undocumented implementation detail of `throw_exception`, it's better to not use it here. As `enable_current_exception` on `throw` is no longer necessary under C++11 as `boost::exception_ptr` automatically uses `std::exception_ptr` when present (https://godbolt.org/z/GPK99jTzY), it's possible to remove this functionality from `wrapexcept` under C++11 to reduce the codegen footprint of using `boost::throw_exception`, and this PR makes sure that `copy_exception` will not be broken by such a future change to `wrapexcept`.