### PR TITLE
Fix two cases of redefinition and hiding of local variables

### DIFF
--- a/include/boost/exception/diagnostic_information.hpp
+++ b/include/boost/exception/diagnostic_information.hpp
@@ -149,11 +149,11 @@ boost
                     if( f )
                         {
                         tmp << *f;
-                        if( int const * l=get_error_info<throw_line>(*be) )
+                        if( l )
                             tmp << '(' << *l << "): ";
                         }
                     tmp << "Throw in function ";
-                    if( char const * const * fn=get_error_info<throw_function>(*be) )
+                    if( fn )
                         tmp << *fn;
                     else
                         tmp << "(unknown)";


### PR DESCRIPTION
There is a minor issue in `boost/exception/diagnostic_information.hpp` that causes the following two MSVC compiler warnings:

```
(...)\boost\exception\diagnostic_information.hpp(152): warning C6246: Local declaration of 'l' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '143' of '(...)\boost\exception\diagnostic_information.hpp'.: Lines: 143
(...)\boost\exception\diagnostic_information.hpp(156): warning C6246: Local declaration of 'fn' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '144' of '(...)\boost\exception\diagnostic_information.hpp'.: Lines: 144
```

Clearly, the outer l and fn can be reused within the else branch.