### PR TITLE
Avoid including deprecated atomic_count.hpp header

### DIFF
--- a/test/copy_exception_test.cpp
+++ b/test/copy_exception_test.cpp
@@ -12,7 +12,7 @@
 #include <boost/exception_ptr.hpp>
 #include <boost/exception/get_error_info.hpp>
 #include <boost/thread.hpp>
-#include <boost/detail/atomic_count.hpp>
+#include <boost/smart_ptr/detail/atomic_count.hpp>
 #include <boost/detail/lightweight_test.hpp>
 
 typedef boost::error_info<struct tag_answer,int> answer;

--- a/test/exception_ptr_test.cpp
+++ b/test/exception_ptr_test.cpp
@@ -16,7 +16,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
-#include <boost/detail/atomic_count.hpp>
+#include <boost/smart_ptr/detail/atomic_count.hpp>
 #include <boost/detail/lightweight_test.hpp>
 #include <iostream>
 


### PR DESCRIPTION
`boost/detail/atomic_count.hpp` was moved into `boost/smart_ptr/detail` and is now deprecated and emits warnings.